### PR TITLE
fixup! add alloc_pages_exact alloc_size attributes

### DIFF
--- a/include/linux/gfp.h
+++ b/include/linux/gfp.h
@@ -515,7 +515,7 @@ extern unsigned long get_zeroed_page(gfp_t gfp_mask);
 
 void *alloc_pages_exact(size_t size, gfp_t gfp_mask) __attribute__((alloc_size(1)));
 void free_pages_exact(void *virt, size_t size);
-void * __meminit alloc_pages_exact_nid(int nid, size_t size, gfp_t gfp_mask) __attribute__((alloc_size(1)));
+void * __meminit alloc_pages_exact_nid(int nid, size_t size, gfp_t gfp_mask) __attribute__((alloc_size(2)));
 
 #define __get_free_page(gfp_mask) \
 		__get_free_pages((gfp_mask), 0)


### PR DESCRIPTION
The index parameter for the alloc_size GCC attribute should be `2` instead of `1` as `size` is the second parameter to `alloc_pages_exact_nid`.

(PR previously opened [here](https://github.com/AndroidHardeningArchive/linux-hardened/pull/83))