### PR TITLE
Require kernel modules to be signed with a valid key

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2004,6 +2004,7 @@ config MODULE_SIG
 
 config MODULE_SIG_FORCE
 	bool "Require modules to be validly signed"
+	default y
 	depends on MODULE_SIG
 	help
 	  Reject unsigned modules or signed modules for which we don't have a


### PR DESCRIPTION
This makes it harder to load a malicious kernel module by requiring them to be signed with a valid key. Any module that is unsigned or signed with an invalid key won't be loaded.

https://www.kernel.org/doc/html/v5.2/admin-guide/module-signing.html