### PR TITLE
 Restrict access to sysfs

### DIFF
--- a/Documentation/admin-guide/sysctl/fs.rst
+++ b/Documentation/admin-guide/sysctl/fs.rst
@@ -48,6 +48,7 @@ Currently, these files are in /proc/sys/fs:
 - suid_dumpable
 - super-max
 - super-nr
+- sysfs_restrict
 
 
 aio-nr & aio-max-nr
@@ -270,6 +271,31 @@ a sticky world-writable directory, or when the uid of the symlink and
 follower match, or when the directory owner matches the symlink's owner.
 
 This protection is based on the restrictions in Openwall and grsecurity.
+
+
+sysfs_restrict
+--------------
+
+This toggle controls the permissions of sysfs (the pseudo-filesystem
+mounted at /sys).
+
+When sysfs_restrict is set to (0), there are no restrictions and
+unprivileged users are permitted to access sysfs. When sysfs_restrict
+is set to (1), sysfs and any filesystem normally mounted under
+it (e.g. debugfs) will be accessible only by root.
+
+These filesystems generally provide access to hardware and debug information
+that isn't appropriate for unprivileged users of the system. Sysfs and
+debugfs have also become a large source of new vulnerabilities, ranging
+from infoleaks to local compromise. There has been very little oversight with
+an eye toward security involved in adding new exporters of information to these
+filesystems, so their use is discouraged.
+
+This is disabled by default as many programs (e.g. Xorg or debugging tools)
+require access to sysfs/debugfs.
+
+The kernel config option CONFIG_SECURITY_SYSFS_RESTRICT sets the default value
+of sysfs_restrict.
 
 
 suid_dumpable:

--- a/fs/debugfs/inode.c
+++ b/fs/debugfs/inode.c
@@ -27,6 +27,7 @@
 #include <linux/magic.h>
 #include <linux/slab.h>
 #include <linux/security.h>
+#include <linux/sysfs.h>
 
 #include "internal.h"
 
@@ -569,7 +570,10 @@ struct dentry *debugfs_create_dir(const char *name, struct dentry *parent)
 		return failed_creating(dentry);
 	}
 
-	inode->i_mode = S_IFDIR | S_IRWXU | S_IRUGO | S_IXUGO;
+	inode->i_mode = S_IRWXU;
+	if (!sysfs_restrict)
+		inode->i_mode = S_IFDIR | S_IRWXU | S_IRUGO | S_IXUGO;
+
 	inode->i_op = &debugfs_dir_inode_operations;
 	inode->i_fop = &simple_dir_operations;
 

--- a/include/linux/sysfs.h
+++ b/include/linux/sysfs.h
@@ -315,6 +315,8 @@ void sysfs_notify(struct kobject *kobj, const char *dir, const char *attr);
 
 int __must_check sysfs_init(void);
 
+extern int sysfs_restrict;
+
 static inline void sysfs_enable_ns(struct kernfs_node *kn)
 {
 	return kernfs_enable_ns(kn);

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -71,6 +71,7 @@
 #include <linux/coredump.h>
 #include <linux/latencytop.h>
 #include <linux/pid.h>
+#include <linux/sysfs.h>
 
 #include "../lib/kstrtox.h"
 
@@ -3371,6 +3372,17 @@ static struct ctl_table fs_table[] = {
 		.extra1		= SYSCTL_ZERO,
 		.extra2		= &two,
 	},
+#ifdef CONFIG_SYSFS
+	{
+		.procname	= "sysfs_restrict",
+		.data		= &sysfs_restrict,
+		.maxlen		= sizeof(int),
+		.mode		= 0600,
+		.proc_handler	= proc_dointvec_minmax_sysadmin,
+		.extra1		= SYSCTL_ZERO,
+		.extra2		= SYSCTL_ONE,
+	},
+#endif
 #if defined(CONFIG_BINFMT_MISC) || defined(CONFIG_BINFMT_MISC_MODULE)
 	{
 		.procname	= "binfmt_misc",

--- a/security/Kconfig
+++ b/security/Kconfig
@@ -42,6 +42,29 @@ config SECURITY_TIOCSTI_RESTRICT
 
 	  If you are unsure how to answer this question, answer N.
 
+config SECURITY_SYSFS_RESTRICT
+	bool "Sysfs/debugfs restriction"
+	default n
+	depends on SYSFS
+	help
+	  If you say Y here, sysfs (the pseudo-filesystem mounted at /sys) and
+	  any filesystem normally mounted under it (e.g. debugfs) will be
+	  accessible only by root. These filesystems generally provide access
+	  to hardware and debug information that isn't appropriate for unprivileged
+	  users of the system. Sysfs and debugfs have also become a large source
+	  of new vulnerabilities, ranging from infoleaks to local compromise.
+	  There has been very little oversight with an eye toward security involved
+	  in adding new exporters of information to these filesystems, so their
+	  use is discouraged.
+
+	  This is disabled by default as many programs (e.g. Xorg or debugging tools)
+	  require access to sysfs/debugfs.
+
+	  This setting can be overridden at runtime via the
+	  fs.sysfs_restrict sysctl.
+
+	  If unsure say N.
+
 config SECURITY
 	bool "Enable different security models"
 	depends on SYSFS


### PR DESCRIPTION
This creates the sysfs_restrict sysctl which restricts access to sysfs. When enabled, sysfs and any filesystem mounted under it (e.g. debugfs) will be accessible only by root.

The default value is set by CONFIG_SECURITY_SYSFS_RESTRICT which is disabled as it breaks too many things to be enabled by default.

This is based on GRKERNSEC_SYSFS_RESTRICT.