### PR TITLE
Harden module auto-loading

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -2902,6 +2902,10 @@
 			log everything. Information is printed at KERN_DEBUG
 			so loglevel=8 may also need to be specified.
 
+	modharden=	[SECURITY]
+			on - Restrict module auto-loading to CAP_SYS_MODULE
+			off - Don't restrict module auto-loading
+
 	module.sig_enforce
 			[KNL] When CONFIG_MODULE_SIG is set, this means that
 			modules without (valid) signatures will fail to load.

--- a/Documentation/admin-guide/sysctl/kernel.rst
+++ b/Documentation/admin-guide/sysctl/kernel.rst
@@ -510,8 +510,22 @@ then the configured static usermode helper overrides this sysctl,
 except that the empty string is still accepted to completely disable
 module autoloading as described above.
 
-modules_disabled
-================
+modharden:
+==========
+
+This toggle indicates whether unprivileged users are allowed to
+auto-load kernel modules.
+
+When modharden is set to (0) there are no restrictions. When
+modharden is set to (1), only users with ``CAP_SYS_MODULE`` are
+permitted to load kernel modules
+
+The kernel config option ``CONFIG_SECURITY_MODHARDEN`` sets the
+default value of modharden.
+
+
+modules_disabled:
+=================
 
 A toggle value indicating if modules are allowed to be loaded
 in an otherwise modular kernel.  This toggle defaults to off

--- a/include/linux/kmod.h
+++ b/include/linux/kmod.h
@@ -22,6 +22,7 @@ extern char modprobe_path[]; /* for sysctl */
  * usually useless though. */
 extern __printf(2, 3)
 int __request_module(bool wait, const char *name, ...);
+extern int modharden;
 #define request_module(mod...) __request_module(true, mod)
 #define request_module_nowait(mod...) __request_module(false, mod)
 #define try_then_request_module(x, mod...) \

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -2111,6 +2111,15 @@ static struct ctl_table kern_table[] = {
 		.extra1		= SYSCTL_ONE,
 		.extra2		= SYSCTL_ONE,
 	},
+	{
+		.procname	= "modharden",
+		.data		= &modharden,
+		.maxlen		= sizeof(int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec_minmax,
+		.extra1		= SYSCTL_ZERO,
+		.extra2		= SYSCTL_ONE,
+	},
 #endif
 #ifdef CONFIG_UEVENT_HELPER
 	{

--- a/security/Kconfig
+++ b/security/Kconfig
@@ -42,6 +42,28 @@ config SECURITY_TIOCSTI_RESTRICT
 
 	  If you are unsure how to answer this question, answer N.
 
+config SECURITY_MODHARDEN
+	bool "Harden module auto-loading"
+	default n
+	depends on MODULES
+	help
+	  If you say Y here, module auto-loading in response to use of some
+	  feature implemented by an unloaded module will be restricted to
+	  CAP_SYS_MODULE. Enabling this option helps defend against attacks
+	  by unprivileged users who abuse the auto-loading behavior to
+	  cause a vulnerable module to load that is then exploited.
+
+	  If this option prevents a legitimate use of auto-loading for a
+	  non-root user, the administrator can execute modprobe manually
+	  with the exact name of the module mentioned in the alert log.
+	  Alternatively, the administrator can add the module to the list
+	  of modules loaded at boot by modifying init scripts.
+
+	  This setting can be overridden at runtime via the
+	  kernel.modharden sysctl.
+
+	  If unsure say N.
+
 config SECURITY
 	bool "Enable different security models"
 	depends on SYSFS


### PR DESCRIPTION
This creates a CONFIG_SECURITY_MODHARDEN option and when enabled, restricts module auto-loading to CAP_SYS_MODULE. This is based on GRKERNSEC_MODHARDEN.