### PR TITLE
log the access to SUID

### DIFF
--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1558,6 +1558,8 @@ static void bprm_fill_uid(struct linux_binprm *bprm)
 		 !kgid_has_mapping(bprm->cred->user_ns, gid))
 		return;
 
+	printk(KERN_ERR "linux-hardened: %s executed by the uid/euid:%u/%u just used a SUID\n", current->comm, current_uid(), current_euid());
+
 	if (mode & S_ISUID) {
 		bprm->per_clear |= PER_CLEAR_ON_SETID;
 		bprm->cred->euid = uid;


### PR DESCRIPTION
Log the access to SUID. The display format is as follows:

[   9.799423] linux-hardened: exim4 executed by the uid/euid:0/0 just used a SUID
[  78.596654] linux-hardened: bash executed by the uid/euid:1000/1000 just used a SUID