### PR TITLE
Make more sysctl constants read-only

### DIFF
--- a/ipc/mq_sysctl.c
+++ b/ipc/mq_sysctl.c
@@ -43,11 +43,11 @@ static int proc_mq_dointvec_minmax(struct ctl_table *table, int write,
 #define proc_mq_dointvec_minmax NULL
 #endif
 
-static int msg_max_limit_min = MIN_MSGMAX;
-static int msg_max_limit_max = HARD_MSGMAX;
+static int msg_max_limit_min __read_only = MIN_MSGMAX;
+static int msg_max_limit_max __read_only = HARD_MSGMAX;
 
-static int msg_maxsize_limit_min = MIN_MSGSIZEMAX;
-static int msg_maxsize_limit_max = HARD_MSGSIZEMAX;
+static int msg_maxsize_limit_min __read_only = MIN_MSGSIZEMAX;
+static int msg_maxsize_limit_max __read_only = HARD_MSGSIZEMAX;
 
 static struct ctl_table mq_sysctls[] = {
 	{

--- a/kernel/sysctl-test.c
+++ b/kernel/sysctl-test.c
@@ -9,8 +9,8 @@
 #define KUNIT_PROC_READ 0
 #define KUNIT_PROC_WRITE 1
 
-static int i_zero;
-static int i_one_hundred = 100;
+static int i_zero __read_only;
+static int i_one_hundred __read_only = 100;
 
 /*
  * Test that proc_dointvec will not try to use a NULL .data field even when the

--- a/lib/test_sysctl.c
+++ b/lib/test_sysctl.c
@@ -36,8 +36,8 @@
 #include <linux/delay.h>
 #include <linux/vmalloc.h>
 
-static int i_zero;
-static int i_one_hundred = 100;
+static int i_zero __read_only;
+static int i_one_hundred __read_only = 100;
 
 struct test_sysctl_data {
 	int int_0001;

--- a/net/ax25/sysctl_net_ax25.c
+++ b/net/ax25/sysctl_net_ax25.c
@@ -9,21 +9,21 @@
 #include <linux/spinlock.h>
 #include <net/ax25.h>
 
-static int min_ipdefmode[1],    	max_ipdefmode[] = {1};
-static int min_axdefmode[1],            max_axdefmode[] = {1};
-static int min_backoff[1],		max_backoff[] = {2};
-static int min_conmode[1],		max_conmode[] = {2};
-static int min_window[] = {1},		max_window[] = {7};
-static int min_ewindow[] = {1},		max_ewindow[] = {63};
-static int min_t1[] = {1},		max_t1[] = {30000};
-static int min_t2[] = {1},		max_t2[] = {20000};
-static int min_t3[1],			max_t3[] = {3600000};
-static int min_idle[1],			max_idle[] = {65535000};
-static int min_n2[] = {1},		max_n2[] = {31};
-static int min_paclen[] = {1},		max_paclen[] = {512};
-static int min_proto[1],		max_proto[] = { AX25_PROTO_MAX };
+static int min_ipdefmode[1],    	max_ipdefmode[] __read_only = {1};
+static int min_axdefmode[1],            max_axdefmode[] __read_only = {1};
+static int min_backoff[1],		max_backoff[] __read_only = {2};
+static int min_conmode[1],		max_conmode[] __read_only = {2};
+static int min_window[] __read_only = {1},		max_window[] __read_only = {7};
+static int min_ewindow[] __read_only = {1},		max_ewindow[] __read_only = {63};
+static int min_t1[] __read_only = {1},		max_t1[] __read_only = {30000};
+static int min_t2[] __read_only = {1},		max_t2[] __read_only = {20000};
+static int min_t3[1],			max_t3[] __read_only = {3600000};
+static int min_idle[1],			max_idle[] __read_only = {65535000};
+static int min_n2[] __read_only = {1},		max_n2[] __read_only = {31};
+static int min_paclen[] __read_only = {1},		max_paclen[] __read_only = {512};
+static int min_proto[1],		max_proto[] __read_only = { AX25_PROTO_MAX };
 #ifdef CONFIG_AX25_DAMA_SLAVE
-static int min_ds_timeout[1],		max_ds_timeout[] = {65535000};
+static int min_ds_timeout[1],		max_ds_timeout[] __read_only = {65535000};
 #endif
 
 static const struct ctl_table ax25_param_table[] = {

--- a/net/core/sysctl_net_core.c
+++ b/net/core/sysctl_net_core.c
@@ -22,13 +22,13 @@
 #include <net/busy_poll.h>
 #include <net/pkt_sched.h>
 
-static int two = 2;
-static int three = 3;
-static int min_sndbuf = SOCK_MIN_SNDBUF;
-static int min_rcvbuf = SOCK_MIN_RCVBUF;
-static int max_skb_frags = MAX_SKB_FRAGS;
-static long long_one __maybe_unused = 1;
-static long long_max __maybe_unused = LONG_MAX;
+static int two __read_only = 2;
+static int three __read_only = 3;
+static int min_sndbuf __read_only = SOCK_MIN_SNDBUF;
+static int min_rcvbuf __read_only = SOCK_MIN_RCVBUF;
+static int max_skb_frags __read_only = MAX_SKB_FRAGS;
+static long long_one __maybe_unused __read_only = 1;
+static long long_max __maybe_unused __read_only = LONG_MAX;
 
 static int net_msg_warn;	/* Unused, but still a sysctl */
 

--- a/net/decnet/sysctl_net_decnet.c
+++ b/net/decnet/sysctl_net_decnet.c
@@ -45,14 +45,14 @@ int sysctl_decnet_rmem[3] = { 4 * 1024, 87380, 87380 * 2 };
 
 #ifdef CONFIG_SYSCTL
 extern int decnet_dst_gc_interval;
-static int min_decnet_time_wait[] = { 5 };
-static int max_decnet_time_wait[] = { 600 };
-static int min_state_count[] = { 1 };
-static int max_state_count[] = { NSP_MAXRXTSHIFT };
-static int min_decnet_dst_gc_interval[] = { 1 };
-static int max_decnet_dst_gc_interval[] = { 60 };
-static int min_decnet_no_fc_max_cwnd[] = { NSP_MIN_WINDOW };
-static int max_decnet_no_fc_max_cwnd[] = { NSP_MAX_WINDOW };
+static int min_decnet_time_wait[] __read_only = { 5 };
+static int max_decnet_time_wait[] __read_only = { 600 };
+static int min_state_count[] __read_only = { 1 };
+static int max_state_count[] __read_only = { NSP_MAXRXTSHIFT };
+static int min_decnet_dst_gc_interval[] __read_only = { 1 };
+static int max_decnet_dst_gc_interval[] __read_only = { 60 };
+static int min_decnet_no_fc_max_cwnd[] __read_only = { NSP_MIN_WINDOW };
+static int max_decnet_no_fc_max_cwnd[] __read_only = { NSP_MAX_WINDOW };
 static char node_name[7] = "???";
 
 static struct ctl_table_header *dn_table_header = NULL;

--- a/net/ipv4/sysctl_net_ipv4.c
+++ b/net/ipv4/sysctl_net_ipv4.c
@@ -28,28 +28,28 @@
 #include <net/protocol.h>
 #include <net/netevent.h>
 
-static int two = 2;
-static int four = 4;
-static int thousand = 1000;
-static int gso_max_segs = GSO_MAX_SEGS;
-static int tcp_retr1_max = 255;
-static int ip_local_port_range_min[] = { 1, 1 };
-static int ip_local_port_range_max[] = { 65535, 65535 };
-static int tcp_adv_win_scale_min = -31;
-static int tcp_adv_win_scale_max = 31;
-static int tcp_min_snd_mss_min = TCP_MIN_SND_MSS;
-static int tcp_min_snd_mss_max = 65535;
-static int ip_privileged_port_min;
-static int ip_privileged_port_max = 65535;
-static int ip_ttl_min = 1;
-static int ip_ttl_max = 255;
-static int tcp_syn_retries_min = 1;
-static int tcp_syn_retries_max = MAX_TCP_SYNCNT;
-static int ip_ping_group_range_min[] = { 0, 0 };
-static int ip_ping_group_range_max[] = { GID_T_MAX, GID_T_MAX };
-static int comp_sack_nr_max = 255;
-static u32 u32_max_div_HZ = UINT_MAX / HZ;
-static int one_day_secs = 24 * 3600;
+static int two __read_only = 2;
+static int four __read_only = 4;
+static int thousand __read_only = 1000;
+static int gso_max_segs __read_only = GSO_MAX_SEGS;
+static int tcp_retr1_max __read_only = 255;
+static int ip_local_port_range_min[] __read_only = { 1, 1 };
+static int ip_local_port_range_max[] __read_only = { 65535, 65535 };
+static int tcp_adv_win_scale_min __read_only = -31;
+static int tcp_adv_win_scale_max __read_only = 31;
+static int tcp_min_snd_mss_min __read_only = TCP_MIN_SND_MSS;
+static int tcp_min_snd_mss_max __read_only = 65535;
+static int ip_privileged_port_min __read_only;
+static int ip_privileged_port_max __read_only = 65535;
+static int ip_ttl_min __read_only = 1;
+static int ip_ttl_max __read_only = 255;
+static int tcp_syn_retries_min __read_only = 1;
+static int tcp_syn_retries_max __read_only = MAX_TCP_SYNCNT;
+static int ip_ping_group_range_min[] __read_only = { 0, 0 };
+static int ip_ping_group_range_max[] __read_only = { GID_T_MAX, GID_T_MAX };
+static int comp_sack_nr_max __read_only = 255;
+static u32 u32_max_div_HZ __read_only = UINT_MAX / HZ;
+static int one_day_secs __read_only = 24 * 3600;
 
 /* obsolete */
 static int sysctl_tcp_low_latency __read_mostly;

--- a/net/ipv6/sysctl_net_ipv6.c
+++ b/net/ipv6/sysctl_net_ipv6.c
@@ -21,10 +21,10 @@
 #include <net/calipso.h>
 #endif
 
-static int two = 2;
-static int flowlabel_reflect_max = 0x7;
-static int auto_flowlabels_min;
-static int auto_flowlabels_max = IP6_AUTO_FLOW_LABEL_MAX;
+static int two __read_only = 2;
+static int flowlabel_reflect_max __read_only = 0x7;
+static int auto_flowlabels_min __read_only;
+static int auto_flowlabels_max __read_only = IP6_AUTO_FLOW_LABEL_MAX;
 
 static int proc_rt6_multipath_hash_policy(struct ctl_table *table, int write,
 					  void *buffer, size_t *lenp, loff_t *ppos)

--- a/net/netrom/sysctl_net_netrom.c
+++ b/net/netrom/sysctl_net_netrom.c
@@ -12,22 +12,22 @@
 /*
  *	Values taken from NET/ROM documentation.
  */
-static int min_quality[] = {0}, max_quality[] = {255};
-static int min_obs[]     = {0}, max_obs[]     = {255};
-static int min_ttl[]     = {0}, max_ttl[]     = {255};
-static int min_t1[]      = {5 * HZ};
-static int max_t1[]      = {600 * HZ};
-static int min_n2[]      = {2}, max_n2[]      = {127};
-static int min_t2[]      = {1 * HZ};
-static int max_t2[]      = {60 * HZ};
-static int min_t4[]      = {1 * HZ};
-static int max_t4[]      = {1000 * HZ};
-static int min_window[]  = {1}, max_window[]  = {127};
-static int min_idle[]    = {0 * HZ};
-static int max_idle[]    = {65535 * HZ};
-static int min_route[]   = {0}, max_route[]   = {1};
-static int min_fails[]   = {1}, max_fails[]   = {10};
-static int min_reset[]   = {0}, max_reset[]   = {1};
+static int min_quality[] __read_only = {0}, max_quality[] __read_only = {255};
+static int min_obs[] __read_only     = {0}, max_obs[] __read_only     = {255};
+static int min_ttl[] __read_only     = {0}, max_ttl[] __read_only     = {255};
+static int min_t1[] __read_only      = {5 * HZ};
+static int max_t1[] __read_only      = {600 * HZ};
+static int min_n2[] __read_only      = {2}, max_n2[] __read_only      = {127};
+static int min_t2[] __read_only      = {1 * HZ};
+static int max_t2[] __read_only      = {60 * HZ};
+static int min_t4[] __read_only      = {1 * HZ};
+static int max_t4[] __read_only      = {1000 * HZ};
+static int min_window[] __read_only  = {1}, max_window[] __read_only  = {127};
+static int min_idle[] __read_only    = {0 * HZ};
+static int max_idle[] __read_only    = {65535 * HZ};
+static int min_route[] __read_only   = {0}, max_route[] __read_only   = {1};
+static int min_fails[] __read_only   = {1}, max_fails[] __read_only   = {10};
+static int min_reset[] __read_only   = {0}, max_reset[] __read_only   = {1};
 
 static struct ctl_table_header *nr_table_header;
 

--- a/net/phonet/sysctl.c
+++ b/net/phonet/sysctl.c
@@ -22,8 +22,8 @@
 #define DYNAMIC_PORT_MAX	0x7f
 
 static DEFINE_SEQLOCK(local_port_range_lock);
-static int local_port_range_min[2] = {0, 0};
-static int local_port_range_max[2] = {1023, 1023};
+static int local_port_range_min[2] __read_only = {0, 0};
+static int local_port_range_max[2] __read_only = {1023, 1023};
 static int local_port_range[2] = {DYNAMIC_PORT_MIN, DYNAMIC_PORT_MAX};
 static struct ctl_table_header *phonet_table_hrd;
 

--- a/net/rose/sysctl_net_rose.c
+++ b/net/rose/sysctl_net_rose.c
@@ -9,15 +9,15 @@
 #include <net/ax25.h>
 #include <net/rose.h>
 
-static int min_timer[]  = {1 * HZ};
-static int max_timer[]  = {300 * HZ};
-static int min_idle[]   = {0 * HZ};
-static int max_idle[]   = {65535 * HZ};
-static int min_route[1],       max_route[] = {1};
-static int min_ftimer[] = {60 * HZ};
-static int max_ftimer[] = {600 * HZ};
-static int min_maxvcs[] = {1}, max_maxvcs[] = {254};
-static int min_window[] = {1}, max_window[] = {7};
+static int min_timer[] __read_only  = {1 * HZ};
+static int max_timer[] __read_only  = {300 * HZ};
+static int min_idle[] __read_only   = {0 * HZ};
+static int max_idle[] __read_only   = {65535 * HZ};
+static int min_route[1],       max_route[] __read_only = {1};
+static int min_ftimer[] __read_only = {60 * HZ};
+static int max_ftimer[] __read_only = {600 * HZ};
+static int min_maxvcs[] __read_only = {1}, max_maxvcs[] = {254};
+static int min_window[] __read_only = {1}, max_window[] = {7};
 
 static struct ctl_table_header *rose_table_header;
 

--- a/net/rxrpc/sysctl.c
+++ b/net/rxrpc/sysctl.c
@@ -11,12 +11,12 @@
 #include "ar-internal.h"
 
 static struct ctl_table_header *rxrpc_sysctl_reg_table;
-static const unsigned int four = 4;
-static const unsigned int thirtytwo = 32;
-static const unsigned int n_65535 = 65535;
-static const unsigned int n_max_acks = RXRPC_RXTX_BUFF_SIZE - 1;
-static const unsigned long one_jiffy = 1;
-static const unsigned long max_jiffies = MAX_JIFFY_OFFSET;
+static const unsigned int four __read_only = 4;
+static const unsigned int thirtytwo __read_only = 32;
+static const unsigned int n_65535 __read_only = 65535;
+static const unsigned int n_max_acks __read_only = RXRPC_RXTX_BUFF_SIZE - 1;
+static const unsigned long one_jiffy __read_only = 1;
+static const unsigned long max_jiffies __read_only = MAX_JIFFY_OFFSET;
 
 /*
  * RxRPC operating parameters.

--- a/net/sctp/sysctl.c
+++ b/net/sctp/sysctl.c
@@ -25,21 +25,21 @@
 #include <net/sctp/sctp.h>
 #include <linux/sysctl.h>
 
-static int timer_max = 86400000; /* ms in one day */
-static int sack_timer_min = 1;
-static int sack_timer_max = 500;
-static int addr_scope_max = SCTP_SCOPE_POLICY_MAX;
-static int rwnd_scale_max = 16;
-static int rto_alpha_min = 0;
-static int rto_beta_min = 0;
-static int rto_alpha_max = 1000;
-static int rto_beta_max = 1000;
-static int pf_expose_max = SCTP_PF_EXPOSE_MAX;
-static int ps_retrans_max = SCTP_PS_RETRANS_MAX;
-static int udp_port_max = 65535;
+static int timer_max __read_only = 86400000; /* ms in one day */
+static int sack_timer_min __read_only = 1;
+static int sack_timer_max __read_only = 500;
+static int addr_scope_max __read_only = SCTP_SCOPE_POLICY_MAX;
+static int rwnd_scale_max __read_only = 16;
+static int rto_alpha_min __read_only = 0;
+static int rto_beta_min __read_only = 0;
+static int rto_alpha_max __read_only = 1000;
+static int rto_beta_max __read_only = 1000;
+static int pf_expose_max __read_only = SCTP_PF_EXPOSE_MAX;
+static int ps_retrans_max __read_only = SCTP_PS_RETRANS_MAX;
+static int udp_port_max __read_only = 65535;
 
-static unsigned long max_autoclose_min = 0;
-static unsigned long max_autoclose_max =
+static unsigned long max_autoclose_min __read_only = 0;
+static unsigned long max_autoclose_max __read_only =
 	(MAX_SCHEDULE_TIMEOUT / HZ > UINT_MAX)
 	? UINT_MAX : MAX_SCHEDULE_TIMEOUT / HZ;
 

--- a/net/x25/sysctl_net_x25.c
+++ b/net/x25/sysctl_net_x25.c
@@ -13,8 +13,8 @@
 #include <linux/init.h>
 #include <net/x25.h>
 
-static int min_timer[] = {   1 * HZ };
-static int max_timer[] = { 300 * HZ };
+static int min_timer[] __read_only = {   1 * HZ };
+static int max_timer[] __read_only = { 300 * HZ };
 
 static struct ctl_table_header *x25_table_header;
 


### PR DESCRIPTION
linux-hardened makes some sysctl constants read-only but there's many more scattered throughout the kernel. This makes a few more of them read-only.