### PR TITLE
Deny access to overly-permissive IPC objects

### DIFF
--- a/Documentation/admin-guide/sysctl/kernel.rst
+++ b/Documentation/admin-guide/sysctl/kernel.rst
@@ -218,6 +218,29 @@ The kernel config option ``CONFIG_SECURITY_DMESG_RESTRICT`` sets the
 default value of ``dmesg_restrict``.
 
 
+harden_ipc
+==========
+
+This toggle indicates whether access to overly-permissive IPC objects
+is disallowed.
+
+If harden_ipc is set to (0), there are no restrictions. If harden_ipc
+is set to (1), access to overly-permissive IPC objects (shared
+memory, message queues, and semaphores) will be denied for processes
+given the following criteria beyond normal permission checks:
+1) If the IPC object is world-accessible and the euid doesn't match
+   that of the creator or current uid for the IPC object
+2) If the IPC object is group-accessible and the egid doesn't
+   match that of the creator or current gid for the IPC object
+It's a common error to grant too much permission to these objects,
+with impact ranging from denial of service and information leaking to
+privilege escalation. This feature was developed in response to
+research by Tim Brown:
+http://labs.portcullis.co.uk/whitepapers/memory-squatting-attacks-on-system-v-shared-memory/
+who found hundreds of such insecure usages. Processes with
+CAP_IPC_OWNER are still permitted to access these IPC objects.
+
+
 domainname & hostname
 =====================
 

--- a/include/linux/ipc.h
+++ b/include/linux/ipc.h
@@ -8,6 +8,8 @@
 #include <uapi/linux/ipc.h>
 #include <linux/refcount.h>
 
+extern int harden_ipc;
+
 /* used by in-kernel data structures */
 struct kern_ipc_perm {
 	spinlock_t	lock;

--- a/ipc/Makefile
+++ b/ipc/Makefile
@@ -4,7 +4,7 @@
 #
 
 obj-$(CONFIG_SYSVIPC_COMPAT) += compat.o
-obj-$(CONFIG_SYSVIPC) += util.o msgutil.o msg.o sem.o shm.o syscall.o
+obj-$(CONFIG_SYSVIPC) += util.o msgutil.o msg.o sem.o shm.o syscall.o harden_ipc.o
 obj-$(CONFIG_SYSVIPC_SYSCTL) += ipc_sysctl.o
 obj-$(CONFIG_POSIX_MQUEUE) += mqueue.o msgutil.o
 obj-$(CONFIG_IPC_NS) += namespace.o

--- a/ipc/harden_ipc.c
+++ b/ipc/harden_ipc.c
@@ -1,0 +1,46 @@
+#include <linux/kernel.h>
+#include <linux/mm.h>
+#include <linux/sched.h>
+#include <linux/file.h>
+#include <linux/ipc.h>
+#include <linux/ipc_namespace.h>
+#include <linux/cred.h>
+
+int harden_ipc __read_mostly = IS_ENABLED(CONFIG_SECURITY_HARDEN_IPC);
+
+int
+ipc_permitted(struct ipc_namespace *ns, struct kern_ipc_perm *ipcp, int requested_mode, int granted_mode)
+{
+	int write;
+	int orig_granted_mode;
+	kuid_t euid;
+	kgid_t egid;
+
+	if (!harden_ipc)
+		return 1;
+
+	euid = current_euid();
+	egid = current_egid();
+
+	write = requested_mode & 00002;
+	orig_granted_mode = ipcp->mode;
+
+	if (uid_eq(euid, ipcp->cuid) || uid_eq(euid, ipcp->uid))
+		orig_granted_mode >>= 6;
+	else {
+		/* if likely wrong permissions, lock to user */
+		if (orig_granted_mode & 0007)
+			orig_granted_mode = 0;
+		/* otherwise do a egid-only check */
+		else if (gid_eq(egid, ipcp->cgid) || gid_eq(egid, ipcp->gid))
+			orig_granted_mode >>= 3;
+		/* otherwise, no access */
+		else
+			orig_granted_mode = 0;
+	}
+	if (!(requested_mode & ~granted_mode & 0007) && (requested_mode & ~orig_granted_mode & 0007) &&
+	    !ns_capable_noaudit(ns->user_ns, CAP_IPC_OWNER)) {
+		return 0;
+	}
+	return 1;
+}

--- a/ipc/util.c
+++ b/ipc/util.c
@@ -76,6 +76,8 @@ struct ipc_proc_iface {
 	int (*show)(struct seq_file *, void *);
 };
 
+extern int ipc_permitted(struct ipc_namespace *ns, struct kern_ipc_perm *ipcp, int requested_mode, int granted_mode);
+
 /**
  * ipc_init - initialise ipc subsystem
  *
@@ -529,6 +531,10 @@ int ipcperms(struct ipc_namespace *ns, struct kern_ipc_perm *ipcp, short flag)
 		granted_mode >>= 6;
 	else if (in_group_p(ipcp->cgid) || in_group_p(ipcp->gid))
 		granted_mode >>= 3;
+
+	if (!ipc_permitted(ns, ipcp, requested_mode, granted_mode))
+		return -1;
+
 	/* is there some bit set in requested_mode but not in granted_mode? */
 	if ((requested_mode & ~granted_mode & 0007) &&
 	    !ns_capable(ns->user_ns, CAP_IPC_OWNER))

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -69,6 +69,7 @@
 #include <linux/mount.h>
 #include <linux/userfaultfd_k.h>
 #include <linux/tty.h>
+#include <linux/ipc.h>
 
 #include "../lib/kstrtox.h"
 
@@ -928,6 +929,17 @@ static struct ctl_table kern_table[] = {
 		.maxlen		= sizeof(int),
 		.mode		= 0644,
 		.proc_handler	= proc_dointvec_minmax_sysadmin,
+		.extra1		= SYSCTL_ZERO,
+		.extra2		= SYSCTL_ONE,
+	},
+#endif
+#ifdef CONFIG_SYSVIPC
+	{
+		.procname	= "harden_ipc",
+		.data		= &harden_ipc,
+		.maxlen		= sizeof(int),
+		.mode		= 0644,
+		.proc_handler	= &proc_dointvec_minmax_sysadmin,
 		.extra1		= SYSCTL_ZERO,
 		.extra2		= SYSCTL_ONE,
 	},

--- a/security/Kconfig
+++ b/security/Kconfig
@@ -42,6 +42,26 @@ config SECURITY_TIOCSTI_RESTRICT
 
 	  If you are unsure how to answer this question, answer N.
 
+config SECURITY_HARDEN_IPC
+	bool "Disallow access to overly-permissive IPC objects"
+	default y
+	depends on SYSVIPC
+	help
+	  If you say Y here, access to overly-permissive IPC objects (shared
+	  memory, message queues, and semaphores) will be denied for processes
+	  given the following criteria beyond normal permission checks:
+	  1) If the IPC object is world-accessible and the euid doesn't match
+	     that of the creator or current uid for the IPC object
+	  2) If the IPC object is group-accessible and the egid doesn't
+	     match that of the creator or current gid for the IPC object
+	  It's a common error to grant too much permission to these objects,
+	  with impact ranging from denial of service and information leaking to
+	  privilege escalation.  This feature was developed in response to
+	  research by Tim Brown:
+	  http://labs.portcullis.co.uk/whitepapers/memory-squatting-attacks-on-system-v-shared-memory/
+	  who found hundreds of such insecure usages. Processes with
+	  CAP_IPC_OWNER are still permitted to access these IPC objects.
+
 config SECURITY
 	bool "Enable different security models"
 	depends on SYSFS


### PR DESCRIPTION
It's a common error to grant too much permission to these objects, with impact ranging from denial of service and information leaking to privilege escalation.

https://labs.portcullis.co.uk/whitepapers/memory-squatting-attacks-on-system-v-shared-memory/

This creates the kernel.harden_ipc sysctl that when enabled will deny access to overly-permissive IPC objects given the following criteria:

1) If the IPC object is world-accessible and the euid doesn't match that of the creator or current uid for the IPC object
2) If the IPC object is group-accessible and the egid doesn't match that of the creator or current gid for the IPC object

Processes with CAP_IPC_OWNER are still permitted to access these IPC objects.

This is based on GRKERNSEC_HARDEN_IPC.