### PR TITLE
Linux-Hardened: Restore align_vdso_addr

### DIFF
--- a/arch/x86/include/asm/elf.h
+++ b/arch/x86/include/asm/elf.h
@@ -407,4 +407,5 @@ struct va_alignment {
 } ____cacheline_aligned;
 
 extern struct va_alignment va_align;
+extern unsigned long align_vdso_addr(unsigned long);
 #endif /* _ASM_X86_ELF_H */

--- a/arch/x86/kernel/sys_x86_64.c
+++ b/arch/x86/kernel/sys_x86_64.c
@@ -52,6 +52,13 @@ static unsigned long get_align_bits(void)
 	return va_align.bits & get_align_mask();
 }
 
+unsigned long align_vdso_addr(unsigned long addr)
+{
+	unsigned long align_mask = get_align_mask();
+	addr = (addr + align_mask) & ~align_mask;
+	return addr | get_align_bits();
+}
+
 static int __init control_va_addr_alignment(char *str)
 {
 	/* guard against enabling this on other CPU families */


### PR DESCRIPTION
Clang16 and 17 throw a C99 error for the missing `align_vdso_addr` function referenced in arch/x86/entry/vdso/vma.c. Daniel removed it in 06aba60cf x86_64: move vdso to mmap region from stack region.

Restore the function delcalration and header without reverting the original mapping mechanism using `vdso_addr` in vma.c.

Fixes:
```
error: call to undeclared function 'align_vdso_addr'; ISO C99 and
later do not support implicit function declarations
[-Wimplicit-function-declaration]
```